### PR TITLE
Add preliminary support for Typescript & Fix Pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+.vscode

--- a/.husky-pre-commit
+++ b/.husky-pre-commit
@@ -1,0 +1,1 @@
+npx pretty-quick --staged

--- a/.husky-pre-commit
+++ b/.husky-pre-commit
@@ -1,1 +1,0 @@
-npx pretty-quick --staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx pretty-quick --staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .package-lock.json
+.tsconfig.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
-.package-lock.json
-.tsconfig.json
+package-lock.json
+tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -285,6 +285,7 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
       "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "\"# christmas_bot_v2\"",
   "main": "index.js",
   "scripts": {
-    "devStart": "nodemon ./server/server.js"
+    "devStart": "nodemon ./server/server.js",
+    "prepare": "husky"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,20 @@
   },
   "devDependencies": {
     "dotenv": "^16.4.5",
+<<<<<<< HEAD
     "nodemon": "^3.1.4"
   }
+=======
+    "husky": "^9.1.6",
+    "nodemon": "^3.1.4",
+    "prettier": "3.3.3",
+    "pretty-quick": "^4.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
+  "type": "module"
+>>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.4.5",
-<<<<<<< HEAD
-    "nodemon": "^3.1.4"
-  }
-=======
     "husky": "^9.1.6",
     "nodemon": "^3.1.4",
     "prettier": "3.3.3",
@@ -28,5 +24,4 @@
     }
   },
   "type": "module"
->>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "prettier": "3.3.3",
     "pretty-quick": "^4.0.0"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,5 @@
     "prettier": "3.3.3",
     "pretty-quick": "^4.0.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
-    }
-  },
   "type": "module"
 }

--- a/server/schemas/community.js
+++ b/server/schemas/community.js
@@ -1,21 +1,24 @@
-const { Schema, model } = require('mongoose');
-const { creatureSchema } = require('./creature');
-const { ornamentSchema } = require('./ornament');
+import { Schema, model } from 'mongoose'
+import { creatureSchema } from './creature.js'
 
 const communitySchema = new Schema({
-    serverId: {
-        type: Number, 
-        required: true
+  serverId: {
+    type: Number,
+    required: true,
+  },
+  foundOrnaments: [
+    {
+      type: Schema.Types.Mixed,
+      default: [],
     },
-    foundOrnaments: [{
-        type: Schema.Types.Mixed,
-        default: []
-    }],
-    foundCreatures: [{
-        type: creatureSchema,
-        default: []
-    }],
-})
- 
+  ],
+  foundCreatures: [
+    {
+      type: creatureSchema,
+      default: [],
+    },
+  ],
+});
+
 const Community = model('Community', communitySchema);
-module.exports = { Community, communitySchema };
+export { Community, communitySchema };

--- a/server/schemas/community.js
+++ b/server/schemas/community.js
@@ -1,5 +1,5 @@
-import { Schema, model } from 'mongoose'
-import { creatureSchema } from './creature.js'
+import { Schema, model } from 'mongoose';
+import { creatureSchema } from './creature.js';
 
 const communitySchema = new Schema({
   serverId: {

--- a/server/schemas/creature.js
+++ b/server/schemas/creature.js
@@ -1,44 +1,40 @@
-const { Schema, model } = require('mongoose');
-const { itemSchema } = require('./item');
-const { playerSchema } = require('./player');
+import { Schema, model } from 'mongoose'
+import { itemSchema } from './item.js'
+import { playerSchema } from './player.js'
 
 const creatureSchema = new Schema({
-    name: {
-        type: String, 
-        required: true,
-        unique: true,
+  name: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  pronoun: {
+    type: String,
+    required: true,
+  },
+  items: [
+    {
+      type: itemSchema,
+      required: true,
     },
-
-    pronoun : {
-        type: String,
-        required: true,
-    },
-
-    items: [{
-        type: itemSchema,
-        required: true,
-    }],
-
-    nature: {
-        type: String, 
-        required: true,
-        validator: (value) => value in ["naughty", "nice"]
-    },
-
-    image: {
-        type: String,
-        default: '',
-    },
-
-    isFound: {
-        type: Boolean,
-        default: false,
-    },
-
-    foundBy: {
-        type: playerSchema,
-    }
-})
+  ],
+  nature: {
+    type: String,
+    required: true,
+    validator: (value) => value in ['naughty', 'nice'],
+  },
+  image: {
+    type: String,
+    default: '',
+  },
+  isFound: {
+    type: Boolean,
+    default: false,
+  },
+  foundBy: {
+    type: playerSchema,
+  },
+});
 
 const Creature = model('Creature', creatureSchema);
-module.exports = { Creature, creatureSchema };
+export { Creature, creatureSchema };

--- a/server/schemas/creature.js
+++ b/server/schemas/creature.js
@@ -1,6 +1,6 @@
-import { Schema, model } from 'mongoose'
-import { itemSchema } from './item.js'
-import { playerSchema } from './player.js'
+import { Schema, model } from 'mongoose';
+import { itemSchema } from './item.js';
+import { playerSchema } from './player.js';
 
 const creatureSchema = new Schema({
   name: {

--- a/server/schemas/item.js
+++ b/server/schemas/item.js
@@ -1,4 +1,4 @@
-import { Schema, model } from 'mongoose'
+import { Schema, model } from 'mongoose';
 
 const itemSchema = new Schema(
   {

--- a/server/schemas/item.js
+++ b/server/schemas/item.js
@@ -1,4 +1,4 @@
-const { Schema, model } = require('mongoose');
+import { Schema, model } from 'mongoose'
 
 const itemSchema = new Schema({
     name: {
@@ -18,4 +18,4 @@ const itemSchema = new Schema({
 }, { discriminatorKey: 'kind'});
 
 const Item = model('Item', itemSchema);
-module.exports = { Item, itemSchema };
+export { Item, itemSchema };

--- a/server/schemas/ornament.js
+++ b/server/schemas/ornament.js
@@ -1,6 +1,6 @@
-const { Schema, model } = require('mongoose');
-const { Item } = require('./item');
-const { playerSchema } = require('./player') 
+import { Schema, model } from 'mongoose'
+import { Item } from './item.js'
+import { playerSchema } from './player.js'
 
 const ornamentSchema = new Schema({
     serverId: {
@@ -17,4 +17,4 @@ const ornamentSchema = new Schema({
 })
 
 const Ornament = Item.discriminator('Ornament', ornamentSchema);
-module.exports = { Ornament, ornamentSchema };
+export { Ornament, ornamentSchema };

--- a/server/schemas/ornament.js
+++ b/server/schemas/ornament.js
@@ -1,6 +1,6 @@
-import { Schema, model } from 'mongoose'
-import { Item } from './item.js'
-import { playerSchema } from './player.js'
+import { Schema, model } from 'mongoose';
+import { Item } from './item.js';
+import { playerSchema } from './player.js';
 
 const ornamentSchema = new Schema({
   serverId: {

--- a/server/schemas/player.js
+++ b/server/schemas/player.js
@@ -1,5 +1,5 @@
-const { Schema, model } = require('mongoose');
-const { itemSchema } = require('./item');
+import { Schema, model } from 'mongoose'
+import { itemSchema } from './item.js'
 
 const playerSchema = new Schema({
     playerId: {
@@ -28,4 +28,4 @@ const playerSchema = new Schema({
 })
 
 const Player = model('Player', playerSchema);
-module.exports = { Player, playerSchema };
+export { Player, playerSchema };

--- a/server/schemas/player.js
+++ b/server/schemas/player.js
@@ -1,5 +1,5 @@
-import { Schema, model } from 'mongoose'
-import { itemSchema } from './item.js'
+import { Schema, model } from 'mongoose';
+import { itemSchema } from './item.js';
 
 const playerSchema = new Schema({
   playerId: {

--- a/server/schemas/settings.js
+++ b/server/schemas/settings.js
@@ -1,4 +1,4 @@
-import { Schema, model } from 'mongoose'
+import { Schema, model } from 'mongoose';
 
 const settingsSchema = new Schema({
   serverId: {

--- a/server/schemas/settings.js
+++ b/server/schemas/settings.js
@@ -1,4 +1,4 @@
-const { Schema, model } = require('mongoose');
+import { Schema, model } from 'mongoose'
 
 const settingsSchema = new Schema({
     serverId: {
@@ -13,4 +13,4 @@ const settingsSchema = new Schema({
 })
 
 const Settings = model('Settings', settingsSchema);
-module.exports = { Settings, settingsSchema };
+export { Settings, settingsSchema };

--- a/server/server.js
+++ b/server/server.js
@@ -1,19 +1,19 @@
 //server dependancies
-import 'dotenv/config'
+import 'dotenv/config';
 const { token, databaseToken } = process.env;
 import mongoose from 'mongoose';
 const { connect, connection } = mongoose;
 
 //utils imports
-import { RARITY } from './utils/constants.js'
+import { RARITY } from './utils/constants.js';
 
 //services imports
-import { createItem } from './services/items-service.js'
-import { createOrnament } from './services/ornaments-service.js'
-import { createPlayer } from './services/players-service.js'
-import { createCreature } from './services/creatures-service.js'
-import { createCommunity } from './services/communities-service.js'
-import { initializeSettings } from './services/settings-service.js'
+import { createItem } from './services/items-service.js';
+import { createOrnament } from './services/ornaments-service.js';
+import { createPlayer } from './services/players-service.js';
+import { createCreature } from './services/creatures-service.js';
+import { createCommunity } from './services/communities-service.js';
+import { initializeSettings } from './services/settings-service.js';
 
 console.log('INITIALIZING CHRISTMAS BOT');
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,19 +1,19 @@
-require("dotenv").config();
+//server dependancies
+import 'dotenv/config'
+const { token, databaseToken } = process.env;
+import mongoose from 'mongoose';
+const { connect, connection } = mongoose;
+
 //utils imports
-const { RARITY } = require('./utils/constants');
+import { RARITY } from './utils/constants.js'
 
 //services imports
-const { createItem } = require('./services/items-service')
-const { createOrnament } = require('./services/ornaments-service')
-const { createPlayer } = require('./services/players-service')
-const { createCreature } = require('./services/creatures-service')
-const { createCommunity } = require('./services/communities-service')
-const { initializeSettings } = require('./services/settings-service')
-
-//server dependancies
-
-const { token, databaseToken } = process.env; 
-const { connect, connection } = require('mongoose');
+import { createItem } from './services/items-service.js'
+import { createOrnament } from './services/ornaments-service.js'
+import { createPlayer } from './services/players-service.js'
+import { createCreature } from './services/creatures-service.js'
+import { createCommunity } from './services/communities-service.js'
+import { initializeSettings } from './services/settings-service.js'
 
 console.log("INITIALIZING CHRISTMAS BOT");
 

--- a/server/services/communities-service.js
+++ b/server/services/communities-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Community } from '../schemas/community.js'
+} from '../utils/helper-functions.js';
+import { Community } from '../schemas/community.js';
 
 /**
  * Creates a community model and adds it the database

--- a/server/services/communities-service.js
+++ b/server/services/communities-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Community } = require('../schemas/community')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Community } from '../schemas/community.js'
 
 /**
  * Creates a community model and adds it the database
@@ -19,7 +22,7 @@ async function createCommunity({serverId, foundOrnaments, foundCreatures}) {
     }
 }
 
-module.exports = { createCommunity }
+export { createCommunity };
 // getCommunityTree()
 
 // getCreatureDex()

--- a/server/services/creatures-service.js
+++ b/server/services/creatures-service.js
@@ -26,7 +26,6 @@ async function createCreature({
   foundBy,
 }) {
   validateRequiredFields({ name, pronoun, items, nature }, 'creature');
-  const test3 = 'urd';
   const creature = new Creature({
     name,
     pronoun,

--- a/server/services/creatures-service.js
+++ b/server/services/creatures-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Creature } from '../schemas/creature.js'
+} from '../utils/helper-functions.js';
+import { Creature } from '../schemas/creature.js';
 
 /**
  * Creates a creature model and adds it the database
@@ -26,8 +26,7 @@ async function createCreature({
   foundBy,
 }) {
   validateRequiredFields({ name, pronoun, items, nature }, 'creature');
-  const test = "yes"
-  const test2 = "yess"
+  const test3 = 'urd';
   const creature = new Creature({
     name,
     pronoun,

--- a/server/services/creatures-service.js
+++ b/server/services/creatures-service.js
@@ -26,7 +26,7 @@ async function createCreature({
   foundBy,
 }) {
   validateRequiredFields({ name, pronoun, items, nature }, 'creature');
-
+  const test = "yes"
   const creature = new Creature({
     name,
     pronoun,

--- a/server/services/creatures-service.js
+++ b/server/services/creatures-service.js
@@ -27,6 +27,7 @@ async function createCreature({
 }) {
   validateRequiredFields({ name, pronoun, items, nature }, 'creature');
   const test = "yes"
+  const test2 = "yess"
   const creature = new Creature({
     name,
     pronoun,

--- a/server/services/creatures-service.js
+++ b/server/services/creatures-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Creature } = require('../schemas/creature')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Creature } from '../schemas/creature.js'
 
 /**
  * Creates a creature model and adds it the database
@@ -23,4 +26,4 @@ async function createCreature({name, pronoun, items, nature, image, isFound, fou
     }
 }
 
-module.exports = { createCreature }
+export { createCreature };

--- a/server/services/items-service.js
+++ b/server/services/items-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Item } = require('../schemas/item')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Item } from '../schemas/item.js'
 
 /**
  * creates an item in the database
@@ -19,4 +22,4 @@ async function createItem({name, rarity, image}) {
     }
 }
 
-module.exports = { createItem }
+export { createItem };

--- a/server/services/items-service.js
+++ b/server/services/items-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Item } from '../schemas/item.js'
+} from '../utils/helper-functions.js';
+import { Item } from '../schemas/item.js';
 
 /**
  * creates an item in the database

--- a/server/services/ornaments-service.js
+++ b/server/services/ornaments-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Ornament } = require('../schemas/ornament')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Ornament } from '../schemas/ornament.js'
 
 /**
  * creates an ornament in the database
@@ -22,4 +25,4 @@ async function createOrnament({name, rarity, serverId, image, isFound, foundBy})
     }
 }
 
-module.exports = { createOrnament }
+export { createOrnament };

--- a/server/services/ornaments-service.js
+++ b/server/services/ornaments-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Ornament } from '../schemas/ornament.js'
+} from '../utils/helper-functions.js';
+import { Ornament } from '../schemas/ornament.js';
 
 /**
  * creates an ornament in the database

--- a/server/services/players-service.js
+++ b/server/services/players-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Player } = require('../schemas/player')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Player } from '../schemas/player.js'
 
 /**
  * creates a player in the database
@@ -28,4 +31,4 @@ async function createPlayer({playerId, serverId, score, inventory, coalCount}) {
 
 // getFoundOrnaments() 
 
-module.exports = { createPlayer }
+export { createPlayer };

--- a/server/services/players-service.js
+++ b/server/services/players-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Player } from '../schemas/player.js'
+} from '../utils/helper-functions.js';
+import { Player } from '../schemas/player.js';
 
 /**
  * creates a player in the database

--- a/server/services/settings-service.js
+++ b/server/services/settings-service.js
@@ -1,5 +1,8 @@
-const { createDatabaseEntry, validateRequiredFields } = require('../utils/helper-functions')
-const { Settings } = require('../schemas/settings')
+import {
+  createDatabaseEntry,
+  validateRequiredFields,
+} from '../utils/helper-functions.js'
+import { Settings } from '../schemas/settings.js'
 
 /**
  * Creates a settings model and adds it the database
@@ -17,4 +20,4 @@ async function initializeSettings({serverId}){
     }
 }
 
-module.exports = { initializeSettings }
+export { initializeSettings };

--- a/server/services/settings-service.js
+++ b/server/services/settings-service.js
@@ -1,8 +1,8 @@
 import {
   createDatabaseEntry,
   validateRequiredFields,
-} from '../utils/helper-functions.js'
-import { Settings } from '../schemas/settings.js'
+} from '../utils/helper-functions.js';
+import { Settings } from '../schemas/settings.js';
 
 /**
  * Creates a settings model and adds it the database

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -6,4 +6,4 @@ const RARITY = {
     LEGENDARY: 0.5,
 }
 
-module.exports = { RARITY }
+export { RARITY };

--- a/server/utils/helper-functions.js
+++ b/server/utils/helper-functions.js
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-const assert = require('assert')
-=======
 import assert from 'assert';
->>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)
 
 /**
  * HELPER FUNCTION: uploads an object to the database
@@ -31,8 +27,4 @@ function validateRequiredFields(requiredFields, objectType){
     }
 }
 
-<<<<<<< HEAD
-module.exports = { createDatabaseEntry, validateRequiredFields }
-=======
 export { createDatabaseEntry, validateRequiredFields };
->>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)

--- a/server/utils/helper-functions.js
+++ b/server/utils/helper-functions.js
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 const assert = require('assert')
+=======
+import assert from 'assert';
+>>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)
 
 /**
  * HELPER FUNCTION: uploads an object to the database
@@ -27,4 +31,8 @@ function validateRequiredFields(requiredFields, objectType){
     }
 }
 
+<<<<<<< HEAD
 module.exports = { createDatabaseEntry, validateRequiredFields }
+=======
+export { createDatabaseEntry, validateRequiredFields };
+>>>>>>> da8f3ca... Add preliminary support for typescript, and convert all imports/exports into ESModule syntax (which is needed for typescript)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ESNext" /* Specify what module code is generated. */,
+    "module": "ESNext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -73,16 +73,16 @@
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
 
     /* Interop Constraints */
-    "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
+    "isolatedModules": true,                             /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
+    "strict": true,                                      /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -105,6 +105,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "ESNext" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
This PR adds preliminary support for typescript by:

- Adding a tsconfig.json file to the root directory to configure the TypeScript compiler options 
- Changing the project to use ES6 modules (import/export instead of require/module.exports), which is recommended by ts

I also realized the pre-commit hook wasn't working, so I fixed it


**AGAIN, PLEASE RUN NPM INSTALL AFTER PULLING FROM LATEST MAIN**